### PR TITLE
use https instead of ssh for docs workflow

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -26,6 +26,6 @@ jobs:
           git init -b main
           git add -A
           git config --global user.email "lionel-bot@aventyret.com"
-          git config --global user.name "Lionel CI bot"
+          git config --global user.name "lionel-bot"
           git commit -m "Publish docs"
-          git push -f git@github.com:$GITHUB_REPOSITORY.git HEAD:gh-pages
+          git push -f https://lionel-bot:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git HEAD:gh-pages

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "lionel-oauth-client",
   "description": "oAuth client with OpenID support.",
   "author": "Äventyret Sweden AB",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "license": "MIT",
   "packageManager": "yarn@3.2.0",
   "homepage": "https://github.com/Aventyret/lionel-oauth-client#readme",


### PR DESCRIPTION
- use-https-instead-of-ssh-for-docs-workflow
- v0.0.18
