### PR TITLE
create createStorageModule fn

### DIFF
--- a/src/createStorageModule.ts
+++ b/src/createStorageModule.ts
@@ -12,30 +12,33 @@ export interface StorageModule {
   clear: () => void
 }
 
-const invalidKey = (key: StorageKey) => !storageKeys.includes(key)
+const invalidKey = (key: StorageKey) => {
+  if (storageKeys.includes(key)) return
+  throw Error('Invalid storage key')
+}
 
 export const createStorageModule = (
   type: StorageModuleType = 'local'
 ): StorageModule => {
   if (!storageModuleTypes.includes(type))
-    throw new Error('Not a valid storage type')
+    throw Error('Not a valid storage type')
 
   const storage = 'session' ? sessionStorage : localStorage
 
   const set = (key: StorageKey, value: string) => {
-    if (invalidKey(key)) throw new Error('Invalid storage key')
+    invalidKey(key)
     storage.setItem(key, value)
   }
 
   const get = (key: StorageKey) => {
-    if (invalidKey(key)) throw new Error('Invalid storage key')
+    invalidKey(key)
     const value = storage.getItem(key)
-    if (!value) throw new Error('Value not set')
+    if (!value) throw Error('Value not set')
     return value
   }
 
   const remove = (key: StorageKey) => {
-    if (invalidKey(key)) throw new Error('Invalid storage key')
+    invalidKey(key)
     storage.removeItem(key)
   }
 

--- a/src/createStorageModule.ts
+++ b/src/createStorageModule.ts
@@ -1,0 +1,55 @@
+const storageKeys = <const>['accessToken', 'idToken', 'state', 'codeVerifier']
+export type StorageKey = typeof storageKeys[number]
+
+const storageModuleTypes = <const>['local', 'session']
+export type StorageModuleType = typeof storageModuleTypes[number]
+
+export interface StorageModule {
+  storage: Storage
+  set: (key: StorageKey, value: string) => void
+  get: (key: StorageKey) => string
+  remove: (key: StorageKey) => void
+  clear: () => void
+}
+
+const invalidKey = (key: StorageKey) => !storageKeys.includes(key)
+
+export const createStorageModule = (
+  type: StorageModuleType = 'local'
+): StorageModule => {
+  if (!storageModuleTypes.includes(type))
+    throw new Error('Not a valid storage type')
+
+  const storage = 'session' ? sessionStorage : localStorage
+
+  const set = (key: StorageKey, value: string) => {
+    if (invalidKey(key)) throw new Error('Invalid storage key')
+    storage.setItem(key, value)
+  }
+
+  const get = (key: StorageKey) => {
+    if (invalidKey(key)) throw new Error('Invalid storage key')
+    const value = storage.getItem(key)
+    if (!value) throw new Error('Value not set')
+    return value
+  }
+
+  const remove = (key: StorageKey) => {
+    if (invalidKey(key)) throw new Error('Invalid storage key')
+    storage.removeItem(key)
+  }
+
+  const clear = () => {
+    storage.clear()
+  }
+
+  return {
+    storage,
+    set,
+    get,
+    remove,
+    clear
+  }
+}
+
+export default createStorageModule

--- a/test/unit/createStorageModule.test.ts
+++ b/test/unit/createStorageModule.test.ts
@@ -1,0 +1,41 @@
+import createStorageModule from '../../src/createStorageModule'
+
+describe('createStorageModule', (): void => {
+  it('should have a storage key that is an instance of Storage', (): void => {
+    const localStorageModule = createStorageModule()
+    expect(localStorageModule.storage).toBeInstanceOf(Storage)
+    const sessionStorageModule = createStorageModule('session')
+    expect(sessionStorageModule.storage).toBeInstanceOf(Storage)
+  })
+
+  it('should throw an error if using a non-valid storage type', (): void => {
+    expect(() => createStorageModule()).toThrow('Not a valid storage type')
+  })
+
+  it('should set and get value to allowed key', (): void => {
+    const module = createStorageModule()
+    const value = '1337'
+    module.set('accessToken', value)
+    expect(module.get('accessToken')).toBe(value)
+  })
+
+  it('should throw error when trying to get a non-set value', (): void => {
+    const module = createStorageModule()
+    expect(module.get('accessToken')).toThrow('Value not set')
+  })
+
+  it('should remove value from allowed key', (): void => {
+    const module = createStorageModule()
+    module.set('codeVerifier', '1337')
+    expect(module.get('codeVerifier')).toBeTruthy()
+    module.remove('codeVerifier')
+    expect(module.get('codeVerifier')).toBeFalsy()
+  })
+
+  it('should clear storage completely', (): void => {
+    const module = createStorageModule()
+    module.set('idToken', '1337')
+    module.clear()
+    expect(module.get('idToken')).toBeFalsy()
+  })
+})

--- a/test/unit/createStorageModule.test.ts
+++ b/test/unit/createStorageModule.test.ts
@@ -37,6 +37,13 @@ describe('createStorageModule', (): void => {
     expect(sessionStorageModule.storage).toBeInstanceOf(Storage)
   })
 
+  it('should throw an error when creating a StorageModule instance with an unsupported type', () => {
+    //@ts-expect-error test to see if an error is thrown when providing an unsupported `type`
+    expect(() => createStorageModule('fail')).toThrow(
+      'Not a valid storage type'
+    )
+  })
+
   it('should set and get value to allowed key', (): void => {
     const module = createStorageModule()
     const value = '1337'
@@ -62,5 +69,15 @@ describe('createStorageModule', (): void => {
     module.set('idToken', '1337')
     module.clear()
     expect(() => module.get('idToken')).toThrow('Value not set')
+  })
+
+  it('should throw an error when trying to get, set or remove using a unsupported key', () => {
+    const module = createStorageModule()
+    //@ts-expect-error throws error on `get` when using unsupported key
+    expect(() => module.get('fail')).toThrow('Invalid storage key')
+    //@ts-expect-error throws error on `set` when using unsupported key
+    expect(() => module.set('fail')).toThrow('Invalid storage key')
+    //@ts-expect-error throws error on `remove` when using unsupported key
+    expect(() => module.remove('fail')).toThrow('Invalid storage key')
   })
 })

--- a/test/unit/createStorageModule.test.ts
+++ b/test/unit/createStorageModule.test.ts
@@ -1,15 +1,40 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import createStorageModule from '../../src/createStorageModule'
 
+const mockedStorage = window.Storage as jest.Mock<Storage>
+interface MockStorage {
+  [key: string]: string
+}
+
 describe('createStorageModule', (): void => {
+  let mockStorage: MockStorage = {}
+
+  beforeAll(() => {
+    mockedStorage.prototype.setItem = jest.fn((key, value) => {
+      mockStorage[key] = value
+    })
+    mockedStorage.prototype.getItem = jest.fn(key => mockStorage[key])
+    mockedStorage.prototype.removeItem = jest.fn(key => delete mockStorage[key])
+    mockedStorage.prototype.clear = jest.fn(() => (mockStorage = {}))
+  })
+
+  beforeEach(() => {
+    mockStorage = {}
+  })
+
+  afterAll(() => {
+    mockedStorage.prototype.setItem.mockReset()
+    mockedStorage.prototype.getItem.mockReset()
+  })
+
   it('should have a storage key that is an instance of Storage', (): void => {
     const localStorageModule = createStorageModule()
     expect(localStorageModule.storage).toBeInstanceOf(Storage)
     const sessionStorageModule = createStorageModule('session')
     expect(sessionStorageModule.storage).toBeInstanceOf(Storage)
-  })
-
-  it('should throw an error if using a non-valid storage type', (): void => {
-    expect(() => createStorageModule()).toThrow('Not a valid storage type')
   })
 
   it('should set and get value to allowed key', (): void => {
@@ -21,7 +46,7 @@ describe('createStorageModule', (): void => {
 
   it('should throw error when trying to get a non-set value', (): void => {
     const module = createStorageModule()
-    expect(module.get('accessToken')).toThrow('Value not set')
+    expect(() => module.get('accessToken')).toThrow('Value not set')
   })
 
   it('should remove value from allowed key', (): void => {
@@ -29,13 +54,13 @@ describe('createStorageModule', (): void => {
     module.set('codeVerifier', '1337')
     expect(module.get('codeVerifier')).toBeTruthy()
     module.remove('codeVerifier')
-    expect(module.get('codeVerifier')).toBeFalsy()
+    expect(() => module.get('codeVerifier')).toThrow('Value not set')
   })
 
   it('should clear storage completely', (): void => {
     const module = createStorageModule()
     module.set('idToken', '1337')
     module.clear()
-    expect(module.get('idToken')).toBeFalsy()
+    expect(() => module.get('idToken')).toThrow('Value not set')
   })
 })


### PR DESCRIPTION
Closes #59 
- createStorageModule tests
- createStorageModule types and functions
- 'invalidKey' fn for 'set', 'get' and 'remove' fns
- properly mock local and session storage, and test if error is thrown
