### PR TITLE
add playwright install-deps to build-and-test workflow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,5 +19,6 @@ jobs:
           node-version: 16
           cache: 'yarn'
       - run: yarn
+      - run: npx playwright install-deps
       - run: yarn test
       - run: yarn build


### PR DESCRIPTION
Relates to #70 

Needs to be merge:d to allow build-and-test workflow to work with [playwright](https://playwright.dev/)