### PR TITLE
fix: header.typ is optional

### DIFF
--- a/src/jwt.ts
+++ b/src/jwt.ts
@@ -67,9 +67,6 @@ export const validateJwtHeader = (header: TokenPart) => {
   if (!header.alg) {
     throw Error('Missing alg in jwt header')
   }
-  if (!header.typ) {
-    throw Error('Missing typ in jwt header')
-  }
   if (!allowedSigningAlgs.includes(header.alg)) {
     throw Error(`${header.alg} is not an allowed signing alg`)
   }

--- a/test/unit/jwt.test.ts
+++ b/test/unit/jwt.test.ts
@@ -27,7 +27,6 @@ describe('parseJwt', (): void => {
   it('should parse an access token and extract correct header and claims', (): void => {
     const parsedAccessToken = parseJwt(accessTokenMock.encoded)
     expect(parsedAccessToken.header.alg).toBe(accessTokenMock.decodedHeader.alg)
-    expect(parsedAccessToken.header.typ).toBe(accessTokenMock.decodedHeader.typ)
     expect(parsedAccessToken.claims.sub).toBe(
       accessTokenMock.decodedPayload.sub
     )


### PR DESCRIPTION
`header.typ` is an optional field according to the RFC and `node-oidc-provider` has now omitted it. However, `lionel-auth` throws an error because it is expecting it.

https://github.com/panva/node-oidc-provider/commit/4eb4004ab66d75eb8627fe6b935fa51f6bbfb80e